### PR TITLE
Bugfix: Zero divisions when calculating FTMS values

### DIFF
--- a/src/peripherals/bluetooth/ble-services/base-metrics.service.cpp
+++ b/src/peripherals/bluetooth/ble-services/base-metrics.service.cpp
@@ -148,11 +148,11 @@ void BaseMetricsBleService::ftmsTask(void *parameters)
         const auto dragFactor = static_cast<unsigned char>(lround(params->data.dragCoefficient * 1e6));
 
         const auto strokeTimeDelta = ((params->data.strokeTime - params->data.previousStrokeTime) / secInMicroSec / 60U);
-        const unsigned char strokeRate = strokeTimeDelta > 0L ? lroundl((params->data.strokeCount - params->data.previousStrokeCount) / strokeTimeDelta) : 0U;
+        const auto strokeRate = static_cast<unsigned char>(strokeTimeDelta > 0 ? lroundl((params->data.strokeCount - params->data.previousStrokeCount) / strokeTimeDelta) : 0);
 
         const auto revTimeDelta = ((params->data.revTime - params->data.previousRevTime) / secInMicroSec);
         const auto distanceDelta = ((params->data.distance - params->data.previousDistance) / 100U);
-        const unsigned short pace500m = distanceDelta > 0L ? lroundl(500U * (revTimeDelta / distanceDelta)) : 0U;
+        const auto pace500m = static_cast<unsigned short>(distanceDelta > 0 ? lroundl(500U * (revTimeDelta / distanceDelta)) : 0);
 
         const auto distance = static_cast<unsigned int>(lround(params->data.distance / 100U));
         const auto avgStrokePower = static_cast<short>(lround(params->data.avgStrokePower));


### PR DESCRIPTION
I found some issues with the calculated FTMS values when I stop rowing for a moment. 
Specifically those were the SPM and the 500m pace, which were set to max value.

In this PR I tried to fix the 0 divisions which cause this.
